### PR TITLE
Port to ROS 2 Jazzy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Ubuntu 18.04 ros melodic base image
-FROM ros:melodic-ros-core-bionic as base
+# Ubuntu 24.04 ROS 2 Jazzy base image
+FROM ros:jazzy-ros-core-noble as base
 
 ARG ROSBAG_SRC_FOLDER
 
@@ -10,53 +10,55 @@ RUN if [ -z "$ROSBAG_SRC_FOLDER" ]; then echo "ROSBAG_SRC argument is not set.\n
 
 # Install dependencies
 RUN apt-get update && apt-get install -y \
-    python-catkin-tools \
-    python-rosdep \
-    python-rosinstall \
-    python-rosinstall-generator \
-    python-wstool \
+    python3-colcon-common-extensions \
+    python3-rosdep \
     build-essential \
-    qtmultimedia5-dev \
-    ros-melodic-cv-bridge \
+    qt6-base-dev \
+    qt6-multimedia-dev \
+    libqt6multimedia6 \
+    libopencv-dev \
+    libx264-dev \
+    ffmpeg \
+    ros-jazzy-cv-bridge \
+    ros-jazzy-rosbag2-cpp \
+    ros-jazzy-rosbag2-storage-mcap \
+    ros-jazzy-rosbag2-storage-default-plugins \
+    ros-jazzy-sensor-msgs \
     && rm -rf /var/lib/apt/lists/
 
 # Initialise rosdep
 RUN rosdep init \
     && rosdep update
 
-# Create user user with password user
-RUN useradd -ms /bin/bash user
-
-# Create XDG_RUNTIME_DIR with correct permissions
-RUN mkdir -p /tmp/runtime-user && chown user:user /tmp/runtime-user && chmod 700 /tmp/runtime-user
+# Create XDG_RUNTIME_DIR with correct permissions for ubuntu user (UID 1000 in base image)
+RUN mkdir -p /tmp/runtime-ubuntu && chown ubuntu:ubuntu /tmp/runtime-ubuntu && chmod 700 /tmp/runtime-ubuntu
 
 # Set the user
-USER user
+USER ubuntu
 
 # Create a workspace
-RUN mkdir -p /home/user/catkin_ws/src
+RUN mkdir -p /home/ubuntu/ros2_ws/src
 
 # Set the workspace
-WORKDIR /home/user/catkin_ws
+WORKDIR /home/ubuntu/ros2_ws
 
 # Copy the source code
-COPY . /home/user/catkin_ws/src
+COPY . /home/ubuntu/ros2_ws/src/bag2vid
 
 USER root
 
 # Install dependencies
-RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && rosdep install --from-paths src --ignore-src -r -y"
+RUN /bin/bash -c "source /opt/ros/jazzy/setup.bash && rosdep install --from-paths src --ignore-src -r -y"
 
 # Set the user
-USER user
+USER ubuntu
 
 # Build the workspace
-RUN /bin/bash -c "source /opt/ros/melodic/setup.bash && catkin build"
+RUN /bin/bash -c "source /opt/ros/jazzy/setup.bash && colcon build --packages-select bag2vid"
 
-ENV XDG_RUNTIME_DIR=/tmp/runtime-user
+ENV XDG_RUNTIME_DIR=/tmp/runtime-ubuntu
 
 # Source the workspace
-RUN echo "source /home/user/catkin_ws/devel/setup.bash" >> /home/user/.bashrc
+RUN echo "source /home/ubuntu/ros2_ws/install/setup.bash" >> /home/ubuntu/.bashrc
 # Set the entrypoint
-# CMD ["/bin/bash"]
-ENTRYPOINT [ "bash", "-c", "source /home/user/catkin_ws/devel/setup.bash && rosrun bag2vid bag2vid_gui" ]
+ENTRYPOINT [ "bash", "-c", "source /home/ubuntu/ros2_ws/install/setup.bash && ros2 run bag2vid bag2vid_gui" ]

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # bag2vid
-A GUI tool to extract videos from a rosbag.
+A GUI tool to extract videos from a rosbag. Supports ROS 2 Jazzy with MCAP bag formats.
+
+> **Looking for the ROS 1 (Melodic) version?** See the [`ros1/melodic`](https://github.com/stathiw/bag2vid/tree/ros1/melodic) branch.
 
 
 

--- a/bag2vid/CMakeLists.txt
+++ b/bag2vid/CMakeLists.txt
@@ -1,259 +1,69 @@
-cmake_minimum_required(VERSION 3.0.2)
+cmake_minimum_required(VERSION 3.14)
 project(bag2vid)
 
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-## Compile as C++11, supported in ROS Kinetic and newer
-add_compile_options(-std=c++17)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
-find_package(catkin REQUIRED COMPONENTS
-  roscpp
-  rosbag
+# ROS 2 dependencies
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rosbag2_cpp REQUIRED)
+find_package(sensor_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(cv_bridge REQUIRED)
+
+# System dependencies
+find_package(OpenCV REQUIRED)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Multimedia MultimediaWidgets)
+
+# Library
+add_library(${PROJECT_NAME}_lib SHARED
+  src/backend/Extractor.cpp
+  src/frontend/Visualiser.cpp
+  src/frontend/Timeline.cpp
+  src/frontend/VideoPlayer.cpp
+  include/bag2vid/frontend/Visualiser.hpp
+  include/bag2vid/frontend/Timeline.hpp
+  include/bag2vid/frontend/VideoPlayer.hpp
+  resources/resources.qrc
+)
+
+target_include_directories(${PROJECT_NAME}_lib PUBLIC include)
+
+ament_target_dependencies(${PROJECT_NAME}_lib
+  rclcpp
+  rosbag2_cpp
   sensor_msgs
   std_msgs
   cv_bridge
 )
 
-find_package(OpenCV REQUIRED)
-find_package(Qt5Widgets REQUIRED)
-find_package(Qt5PrintSupport REQUIRED)
-find_package(Qt5Multimedia REQUIRED)
-find_package(Qt5MultimediaWidgets REQUIRED)
-
-## System dependencies are found with CMake's conventions
-# find_package(Boost REQUIRED COMPONENTS system)
-
-
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
-
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend tag for "message_generation"
-##   * add a build_depend and a exec_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependency has been pulled in
-##     but can be declared for certainty nonetheless:
-##     * add a exec_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   sensor_msgs#   std_msgs
-# )
-
-################################################
-## Declare ROS dynamic reconfigure parameters ##
-################################################
-
-## To declare and build dynamic reconfigure parameters within this
-## package, follow these steps:
-## * In the file package.xml:
-##   * add a build_depend and a exec_depend tag for "dynamic_reconfigure"
-## * In this file (CMakeLists.txt):
-##   * add "dynamic_reconfigure" to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * uncomment the "generate_dynamic_reconfigure_options" section below
-##     and list every .cfg file to be processed
-
-## Generate dynamic reconfigure parameters in the 'cfg' folder
-# generate_dynamic_reconfigure_options(
-#   cfg/DynReconf1.cfg
-#   cfg/DynReconf2.cfg
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if your package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
-catkin_package(
-  CATKIN_DEPENDS roscpp sensor_msgs std_msgs rosbag
-  INCLUDE_DIRS include
-  LIBRARIES bag2vid
-  DEPENDS Qt5Widgets Qt5PrintSupport Qt5Multimedia Qt5MultimediaWidgets
-)
-
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-include_directories(
-  include
-  ${catkin_INCLUDE_DIRS}
-  ${Qt5Widgets_INCLUDE_DIRS}
-  ${Qt5Multimedia_INCLUDE_DIRS}
-  ${Qt5MultimediaWidgets_INCLUDE_DIRS}
-)
-
-## Declare a C++ library
-add_library(${PROJECT_NAME} SHARED
-  src/backend/Extractor.cpp
-  src/frontend/Visualiser.cpp
-  src/frontend/Timeline.cpp
-  src/frontend/VideoPlayer.cpp
-)
-
-## Add cmake target dependencies of the library
-## as an example, code may need to be generated before libraries
-## either from message generation or dynamic reconfigure
-# add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-# add_dependencies(${PROJECT_NAME}_node ${catkin_EXPORTED_TARGETS})
-# add_dependencies(${PROJECT_NAME}_gui ${catkin_EXPORTED_TARGETS})
-
-target_link_libraries(${PROJECT_NAME}
-  ${catkin_LIBRARIES}
+target_link_libraries(${PROJECT_NAME}_lib
   ${OpenCV_LIBS}
-  Qt5::Core
-  Qt5::Gui
-  Qt5::Widgets
-  Qt5::Multimedia
-  Qt5::MultimediaWidgets
+  Qt6::Core
+  Qt6::Gui
+  Qt6::Widgets
+  Qt6::Multimedia
+  Qt6::MultimediaWidgets
 )
 
-## Add Qt-specific settings
-set(CMAKE_AUTOMOC ON)
-set(CMAKE_AUTORCC ON)
-set(CMAKE_AUTOUIC ON)
+# GUI executable
+add_executable(bag2vid_gui nodes/bag2vid_gui.cpp)
+target_link_libraries(bag2vid_gui ${PROJECT_NAME}_lib)
 
-qt5_wrap_cpp(MOC_SOURCES include/bag2vid/frontend/Visualiser.hpp include/bag2vid/frontend/Timeline.hpp include/bag2vid/frontend/VideoPlayer.hpp)
-qt5_add_resources(QRC_SOURCES resources/resources.qrc)
+# CLI executable
+add_executable(bag2vid_node nodes/bag2vid_node.cpp)
+target_link_libraries(bag2vid_node ${PROJECT_NAME}_lib)
 
-## Declare a C++ executable
-## With catkin_make all packages are built within a single CMake context
-## The recommended prefix ensures that target names across packages don't collide
-add_executable(bag2vid_node nodes/bag2vid_node.cpp ${MOC_SOURCES})
-add_executable(bag2vid_gui nodes/bag2vid_gui.cpp src/frontend/Visualiser.cpp src/frontend/VideoPlayer.cpp ${MOC_SOURCES} ${QRC_SOURCES})
-
-## Rename C++ executable without prefix
-## The above recommended prefix causes long target names, the following renames the
-## target back to the shorter version for ease of user use
-## e.g. "rosrun someones_pkg node" instead of "rosrun someones_pkg someones_pkg_node"
-# set_target_properties(${PROJECT_NAME}_node PROPERTIES OUTPUT_NAME node PREFIX "")
-
-## Add cmake target dependencies of the executable
-## same as for the library above
-# add_dependencies(${PROJECT_NAME}_node ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-
-## Specify libraries to link a library or executable target against
-target_link_libraries(${PROJECT_NAME}_node
-  ${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBS}
+# Install
+install(TARGETS ${PROJECT_NAME}_lib bag2vid_gui bag2vid_node
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION lib/${PROJECT_NAME}
 )
 
-## Specify libraries to link a library or executable target against
-target_link_libraries(${PROJECT_NAME}_gui
-  ${PROJECT_NAME}
-  ${catkin_LIBRARIES}
-  ${OpenCV_LIBS}
-  Qt5::Core
-  Qt5::Gui
-  Qt5::Widgets
-  Qt5::Multimedia
-  Qt5::MultimediaWidgets
-)
-
-# add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
-
-#############
-## Install ##
-#############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# catkin_install_python(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark executables for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_executables.html
-# install(TARGETS ${PROJECT_NAME}_node
-#   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
-
-## Mark libraries for installation
-## See http://docs.ros.org/melodic/api/catkin/html/howto/format1/building_libraries.html
-# install(TARGETS ${PROJECT_NAME}
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-# )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_bag2vid.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)
+ament_package()

--- a/bag2vid/include/bag2vid/Types.hpp
+++ b/bag2vid/include/bag2vid/Types.hpp
@@ -8,16 +8,16 @@
 
 #pragma once
 
-#include <sensor_msgs/CompressedImage.h>
-#include <sensor_msgs/Image.h>
-#include <rosbag/message_instance.h>
+#include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/msg/image.hpp>
+#include <rosbag2_storage/serialized_bag_message.hpp>
 
 
 namespace bag2vid
 {
 
-using ImagePtr = std::shared_ptr<sensor_msgs::Image>;
-using CompressedImagePtr = std::shared_ptr<sensor_msgs::CompressedImage>;
-using MessageInstancePtr = std::shared_ptr<rosbag::MessageInstance>;
+using ImagePtr = std::shared_ptr<sensor_msgs::msg::Image>;
+using CompressedImagePtr = std::shared_ptr<sensor_msgs::msg::CompressedImage>;
+using MessageInstancePtr = std::shared_ptr<rosbag2_storage::SerializedBagMessage>;
 
 } // namespace bag2vid

--- a/bag2vid/include/bag2vid/backend/Camera.hpp
+++ b/bag2vid/include/bag2vid/backend/Camera.hpp
@@ -3,18 +3,18 @@
  * @author Stathi Weir (stathi.weir@gmail.com)
  * @brief
  * @version 0.1
- * @date 2024-06-09 
+ * @date 2024-06-09
  */
 
 #pragma once
 
-#include <rosbag/bag.h>
-#include <rosbag/view.h>
+#include <string>
+#include <vector>
+#include <memory>
 
-#include <sensor_msgs/CompressedImage.h>
-#include <sensor_msgs/Image.h>
+#include <rosbag2_storage/serialized_bag_message.hpp>
 
-namespace bag2vid 
+namespace bag2vid
 {
 class Camera
 {
@@ -28,7 +28,7 @@ class Camera
      * @brief Add messages to the camera
      */
     void addMessages(
-        const std::vector<std::shared_ptr<rosbag::MessageInstance>> &messages);
+        const std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> &messages);
 
     /**
      * @brief Get the name of the camera
@@ -46,19 +46,19 @@ class Camera
     inline std::string getImageType() const { return image_type_; }
 
     /**
-     * @brief Get the start time of the camera
+     * @brief Get the start time of the camera (seconds)
      */
-    inline ros::Time getStartTime() const { return start_time_; }
+    inline double getStartTime() const { return start_time_; }
 
     /**
-     * @brief Get the end time of the camera
+     * @brief Get the end time of the camera (seconds)
      */
-    inline ros::Time getEndTime() const { return end_time_; }
+    inline double getEndTime() const { return end_time_; }
 
     /**
      * @brief Get the messages of the camera
      */
-    inline std::vector<std::shared_ptr<rosbag::MessageInstance>>
+    inline std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>>
     getMessages() const {
       return messages_;
     }
@@ -68,10 +68,10 @@ class Camera
     std::string topic_;
     std::string image_type_;
 
-    ros::Time start_time_;
-    ros::Time end_time_;
+    double start_time_;
+    double end_time_;
 
-    std::vector<std::shared_ptr<rosbag::MessageInstance>> messages_;
+    std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages_;
 };
 
 } // namespace bag2vid

--- a/bag2vid/include/bag2vid/backend/Extractor.hpp
+++ b/bag2vid/include/bag2vid/backend/Extractor.hpp
@@ -3,7 +3,7 @@
  * @author Stathi Weir (stathi.weir@gmail.com)
  * @brief
  * @version 0.1
- * @date 2024-06-09 
+ * @date 2024-06-09
  */
 
 #pragma once
@@ -12,17 +12,20 @@
 
 #include <iostream>
 #include <functional>
+#include <map>
 
-#include <cv_bridge/cv_bridge.h>
+#include <cv_bridge/cv_bridge.hpp>
 #include <opencv2/videoio.hpp>
 #include <opencv2/imgcodecs.hpp>
 
-#include <ros/ros.h>
-#include <rosbag/bag.h>
-#include <rosbag/view.h>
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <rosbag2_cpp/reader.hpp>
+#include <rosbag2_storage/storage_filter.hpp>
+#include <rosbag2_storage/storage_options.hpp>
 
-#include <sensor_msgs/CompressedImage.h>
-#include <sensor_msgs/Image.h>
+#include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/msg/image.hpp>
 
 namespace bag2vid
 {
@@ -32,8 +35,7 @@ public:
   using ProgressCallback = std::function<void(int)>;
 
   inline Extractor() {}
-  inline ~Extractor() { 
-    bag_.close();
+  inline ~Extractor() {
     progress_callback_ = nullptr;
   }
 
@@ -47,29 +49,18 @@ public:
 
   void closeBag();
 
-  inline double getBagStartTime() { return bag_start_time_.toSec(); }
-  
-  inline double getBagEndTime() { return bag_end_time_.toSec(); }
+  inline double getBagStartTime() { return bag_start_time_sec_; }
+
+  inline double getBagEndTime() { return bag_end_time_sec_; }
 
   std::vector<std::string> getImageTopics();
 
+  /**
+   * @brief Get the message type string for a given topic
+   */
+  std::string getTopicType(const std::string& topic);
+
   std::vector<bag2vid::MessageInstancePtr> extractMessages(const std::string &topic, const std::string &camera_name);
-
-  /**
-   * @brief Extracts all images from the given topic
-   *
-   * @param topic The topic to extract images from
-   * @return A vector of shared pointers to the extracted images
-   */
-  std::vector<bag2vid::ImagePtr> extractImages(const std::string &topic, const std::string &camera_name);
-
-  /**
-   * @brief Extracts all compressed images from the given topic
-   *
-   * @param topic The topic to extract compressed images from
-   * @return A vector of shared pointers to the extracted compressed images
-   */
-  std::vector<bag2vid::CompressedImagePtr> extractCompressedImages(const std::string &topic);
 
   /**
    * @brief Captures a screenshot of the current video frame
@@ -84,35 +75,46 @@ public:
    * @brief Writes to video between the given timestamps from the given topic
    *
    * @param topic The topic to extract images from
-   * @param start_time The start time of the video
-   * @param end_time The end time of the video
+   * @param start_time The start time of the video (seconds)
+   * @param end_time The end time of the video (seconds)
    * @param video_file The path to the video file
    * @return True if the video was written successfully, false otherwise
    */
-  bool writeVideo(const std::string &topic, const ros::Time &start_time,
-                  const ros::Time &end_time, const std::string &video_file);
+  bool writeVideo(const std::string &topic, const double &start_time,
+                  const double &end_time, const std::string &video_file);
 
   void setProgressCallback(ProgressCallback callback);
 
 private:
-  rosbag::Bag bag_;
+  std::unique_ptr<rosbag2_cpp::Reader> reader_;
 
   // Rosbag file path
   std::string bag_file_;
 
-  // Bag start time and end time
-  ros::Time bag_start_time_;
-  ros::Time bag_end_time_;
+  // Bag start time and end time (seconds)
+  double bag_start_time_sec_ = 0.0;
+  double bag_end_time_sec_ = 0.0;
 
   std::vector<std::string> image_topics_;
 
-  // Dictionay of image topics
-  // Maps topic names to a vector of shared pointers to the image messages
+  // Maps topic name to its message type string
+  std::map<std::string, std::string> topic_type_map_;
+
+  // Maps camera name to its topic name
+  std::map<std::string, std::string> camera_topic_map_;
+
+  // Dictionary of image topics
+  // Maps camera names to a vector of shared pointers to the serialized messages
   std::map<std::string, std::vector<bag2vid::MessageInstancePtr>> image_data_;
 
   cv::VideoWriter video_writer_;
 
   ProgressCallback progress_callback_;
+
+  /**
+   * @brief Deserialize a serialized bag message to a cv::Mat image
+   */
+  cv::Mat deserializeToImage(const bag2vid::MessageInstancePtr& msg, const std::string& type_str);
 };
 
 } // namespace bag2vid

--- a/bag2vid/include/bag2vid/frontend/VideoPlayer.hpp
+++ b/bag2vid/include/bag2vid/frontend/VideoPlayer.hpp
@@ -2,10 +2,11 @@
 
 #pragma once
 
-#include <ros/ros.h>
-#include <sensor_msgs/CompressedImage.h>
-#include <sensor_msgs/Image.h>
-#include <rosbag/bag.h>
+#include <rosbag2_storage/serialized_bag_message.hpp>
+#include <rclcpp/serialization.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <sensor_msgs/msg/compressed_image.hpp>
+#include <sensor_msgs/msg/image.hpp>
 
 #include <QImage>
 #include <QObject>
@@ -18,20 +19,20 @@ class VideoPlayer : public QObject
 public:
     /**
      * @brief Construct a new VideoPlayer object.
-     * 
-     * @param parent 
+     *
+     * @param parent
      */
     explicit VideoPlayer(QObject *parent = nullptr);
 
     /**
      * @brief Destroy the VideoPlayer object.
-     * 
+     *
      */
     ~VideoPlayer();
 
     /**
      * @brief Get the current frame id.
-     * 
+     *
      * @return int
      */
     int getCurrentFrameId() const { return current_frame_; }
@@ -40,7 +41,7 @@ public slots:
     /**
      * @brief Move the video player to the specified time (in seconds).
      * First frame of the rosbag is at time 0.
-     * 
+     *
      * @param time
      */
     void seekToTime(double time);
@@ -57,10 +58,12 @@ public slots:
 
     /**
      * @brief Load messages from a rosbag.
-     * 
-     * @param messages Vector of shared pointers to rosbag message instances.
+     *
+     * @param messages Vector of shared pointers to serialized bag messages.
+     * @param message_type The ROS message type string (e.g. "sensor_msgs/msg/Image").
      */
-    void loadMessages(std::vector<std::shared_ptr<rosbag::MessageInstance> > messages);
+    void loadMessages(std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages,
+                      const std::string& message_type);
 
     /**
      * @brief Move the video player to the previous frame.
@@ -75,22 +78,22 @@ public slots:
 signals:
     /**
      * @brief Signal emitted when a new frame is available.
-     * 
+     *
      * @param frame
      */
     void newFrame(const QImage &frame);
 
     /**
      * @brief Set the timestamp of the current frame.
-     * 
-     * @param time 
-     * @return * void 
+     *
+     * @param time
+     * @return * void
      */
     void currentTimestamp(double time);
 
     /**
      * @brief Signal emitted when the video has finished playing.
-     * 
+     *
      */
     void finishedPlaying();
 
@@ -108,20 +111,29 @@ private:
     double end_time_;
     // Timer for playback
     QTimer playback_timer_;
-    // Vector of shared pointers to rosbag message instances
-    std::vector<std::shared_ptr<rosbag::MessageInstance> > messages_;
+    // Vector of shared pointers to serialized bag messages
+    std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages_;
+    // The ROS message type string for this set of messages
+    std::string message_type_;
+
+    /**
+     * @brief Process and emit a frame from the message at the given index.
+     *
+     * @param index The index into messages_.
+     */
+    void processFrame(int index);
 
     /**
      * @brief Process ROS Image message.
-     * 
+     *
      * @param msg std::shared_ptr to the Image message.
      */
-    void processImageMessage(const sensor_msgs::Image::ConstPtr &msg);
+    void processImageMessage(const sensor_msgs::msg::Image::SharedPtr &msg);
 
     /**
      * @brief Process ROS CompressedImage message.
-     * 
+     *
      * @param msg std::shared_ptr to the CompressedImage message.
      */
-    void processCompressedImageMessage(const sensor_msgs::CompressedImage::ConstPtr &msg);
+    void processCompressedImageMessage(const sensor_msgs::msg::CompressedImage::SharedPtr &msg);
 };

--- a/bag2vid/include/bag2vid/frontend/Visualiser.hpp
+++ b/bag2vid/include/bag2vid/frontend/Visualiser.hpp
@@ -9,25 +9,20 @@
 
 #include <iostream>
 
-#include <QMainWindow>
-#include <QVideoWidget>
 #include <QFileDialog>
 #include <QLabel>
 #include <QComboBox>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
-#include <QMediaPlayer>
 #include <QSlider>
 #include <QPushButton>
 #include <QProgressBar>
-
-#include <ros/ros.h>
 
 #include <bag2vid/backend/Extractor.hpp>
 #include <bag2vid/frontend/Timeline.hpp>
 #include <bag2vid/frontend/VideoPlayer.hpp>
 
-namespace bag2vid 
+namespace bag2vid
 {
 
 class Visualiser : public QWidget
@@ -44,46 +39,46 @@ public:
 private slots:
     /**
      * @brief Load a rosbag file into the video extractor.
-     * 
+     *
      */
     void loadBag();
 
     /**
      * @brief Toggle the play/pause state of the video player.
-     * 
+     *
      */
     void togglePlayPause();
-    
+
     /**
      * @brief Extract the video from the rosbag file for the selected topic between the selected start and end times.
-     * 
+     *
      */
     void extractVideo();
-    
+
     /**
      * @brief Update the dropdown list of topics from the loaded rosbag file.
-     * 
+     *
      */
     void updateTopicDropdown();
 
     /**
      * @brief Capture a screenshot of the current frame.
-     * 
+     *
      */
     void captureScreenshot();
 
 protected:
     /**
      * @brief Resize event handler.
-     * 
-     * @param event 
+     *
+     * @param event
      */
     void resizeEvent(QResizeEvent *event) override;
-    
+
     /**
      * @brief Key press event handler.
-     * 
-     * @param event 
+     *
+     * @param event
      */
     void keyPressEvent(QKeyEvent *event) override;
 
@@ -110,15 +105,14 @@ private:
 
     /**
      * @brief Set up the GUI elements.
-     * 
+     *
      */
     void setupUI();
 
     /**
-     * @brief Update the progress bar 
-     * 
+     * @brief Update the progress bar
+     *
      */
     void updateProgressBar(int progress);
 };
 } // namespace bag2vid
-

--- a/bag2vid/nodes/bag2vid_gui.cpp
+++ b/bag2vid/nodes/bag2vid_gui.cpp
@@ -1,8 +1,6 @@
 
 #include <QApplication>
 
-#include <ros/ros.h>
-
 #include "bag2vid/frontend/Visualiser.hpp"
 
 int main(int argc, char** argv)

--- a/bag2vid/nodes/bag2vid_node.cpp
+++ b/bag2vid/nodes/bag2vid_node.cpp
@@ -1,55 +1,30 @@
 #include "bag2vid/backend/Extractor.hpp"
 
-#include <ros/ros.h>
-
 int main(int argc, char** argv)
 {
-    ros::init(argc, argv, "bag2vid");
-    ros::NodeHandle nh;
+    std::string bag_file = "";
+    std::string topic = "";
+    std::string camera_name = "";
+    std::string output_file = "";
 
-    std::string bag_file = "/home/octopus/Hullbot_bag_files/240326_ribecca/H6_Stingaree_humu_ribecca_vaucluse_bay_survey_manual_transect_2__2024-03-27-01-07-20.bag";
-    std::string topic = "/camera_4/image_raw_relay/compressed";
-    std::string camera_name = "camera_4";
-    std::string output_file = "/home/octopus/Downloads/TestExtractedVideo.mp4";
+    // Prompt user for input
+    std::cout << "Enter the path to the bag file: ";
+    std::getline(std::cin, bag_file);
 
-    /*
-    std::string bag_file = "/home/octopus/Hullbot_bag_files/240529_chapman_foil/H6_Barracuda_MAC48b02d883315_chapman_foil_syd_bh_clean__2024-05-29-03-52-03.bag";
-    std::string topic = "/camera_2/image_raw_relay/compressed";
-    std::string camera_name = "camera_2";
-    std::string output_file = "/home/octopus/Downloads/ChapmanMarineFrontCamClean.mp4";
-    */
+    std::cout << "Enter the topic to extract: ";
+    std::getline(std::cin, topic);
 
-    // If --dev flag is passed, run in development mode
-    if (argc > 1 && std::string(argv[1]) == "--dev")
-    {
-        std::cout << "Running in development mode" << std::endl;
-    }
-    // Otherwise, prompt user for input
-    else
-    {
-        // Prompt user for bag file
-        std::cout << "Enter the path to the bag file: ";
-        std::getline(std::cin, bag_file);
-    
-        // Prompt user for topic
-        std::cout << "Enter the topic to extract: ";
-        std::getline(std::cin, topic);
-    
-        std::cout << "Enter the camera name: ";
-        std::getline(std::cin, camera_name);
-    
-        // Prompt user for output file
-        std::cout << "Enter the path to the output file: ";
-        std::getline(std::cin, output_file);
-    }
-    
+    std::cout << "Enter the camera name: ";
+    std::getline(std::cin, camera_name);
+
+    std::cout << "Enter the path to the output file: ";
+    std::getline(std::cin, output_file);
+
     std::cout << "Extracting topic " << topic << " from " << bag_file << " to " << output_file << std::endl;
 
     // Ask user to confirm
     std::string confirm;
-
     std::cout << "Confirm? (y/n): ";
-
     std::getline(std::cin, confirm);
 
     if (confirm != "y")
@@ -71,15 +46,14 @@ int main(int argc, char** argv)
 
     // Extract the messages
     std::cout << "Extracting messages..." << std::endl;
-    std::vector<std::shared_ptr<rosbag::MessageInstance>> messages = b2v.extractMessages(topic, camera_name);
+    std::vector<bag2vid::MessageInstancePtr> messages = b2v.extractMessages(topic, camera_name);
     std::cout << "Extracted " << messages.size() << " messages" << std::endl;
-
 
     // Write the messages to a file
     std::cout << "Writing messages to file..." << std::endl;
     // Make start_time and end_time 0 to write all messages
-    ros::Time start_time = ros::Time(0);
-    ros::Time end_time = ros::Time(0);
+    double start_time = 0.0;
+    double end_time = 0.0;
     if (!b2v.writeVideo(camera_name, start_time, end_time, output_file))
     {
         std::cout << "Failed to write messages to file" << std::endl;

--- a/bag2vid/package.xml
+++ b/bag2vid/package.xml
@@ -1,71 +1,21 @@
 <?xml version="1.0"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd"?>
+<package format="3">
   <name>bag2vid</name>
-  <version>0.0.0</version>
-  <description>The bag2vid package</description>
+  <version>2.0.0</version>
+  <description>GUI tool for extracting videos from rosbags</description>
+  <maintainer email="stathi.weir@gmail.com">Stathi Weir</maintainer>
+  <license>GPLv3 + Commons Clause</license>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="octopus@todo.todo">octopus</maintainer>
+  <buildtool_depend>ament_cmake</buildtool_depend>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
-
-
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/bag2vid</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
-  <buildtool_depend>catkin</buildtool_depend>
-  <depend>rosbag</depend>
+  <depend>rclcpp</depend>
+  <depend>rosbag2_cpp</depend>
+  <depend>sensor_msgs</depend>
+  <depend>std_msgs</depend>
   <depend>cv_bridge</depend>
-  <depend>qt5</depend>
-  <build_depend>roscpp</build_depend>
-  <build_depend>sensor_msgs</build_depend>
-  <build_depend>std_msgs</build_depend>
-  <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>sensor_msgs</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
-  <exec_depend>roscpp</exec_depend>
-  <exec_depend>sensor_msgs</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
   <export>
-    <!-- Other tools can request additional information be placed here -->
-
+    <build_type>ament_cmake</build_type>
   </export>
 </package>

--- a/bag2vid/scripts/bag2vid.sh
+++ b/bag2vid/scripts/bag2vid.sh
@@ -3,7 +3,7 @@
 # Variables
 BAG2VID_IMAGE="stathiw/bag2vid:latest"
 CONTAINER_NAME="bag2vid"
-BAG2VID_SRC="/home/${USER}/Hullbot_bag_files"  # Replace with the path to your ROS bags
+BAG2VID_SRC="/home/${USER}/rosbags"  # Replace with the path to your ROS bags
 DISPLAY_VAR=${DISPLAY}
 
 # Run the Docker container
@@ -11,8 +11,8 @@ docker run -it --rm \
   --name ${CONTAINER_NAME} \
   --env DISPLAY=${DISPLAY_VAR} \
   --volume /tmp/.X11-unix:/tmp/.X11-unix \
-  --volume ${BAG2VID_SRC}:/home/user/rosbags \
+  --volume ${BAG2VID_SRC}:/home/ubuntu/rosbags \
   --network host \
   --privileged \
   ${BAG2VID_IMAGE} \
-  bash -c "source /opt/ros/melodic/setup.bash && rosrun bag2vid bag2vid_gui"
+  bash -c "source /opt/ros/jazzy/setup.bash && ros2 run bag2vid bag2vid_gui"

--- a/bag2vid/scripts/install.sh
+++ b/bag2vid/scripts/install.sh
@@ -3,7 +3,7 @@
 
 # Variables
 BAG2VID_IMAGE="stathiw/bag2vid:latest"
-BAG2VID_SRC="/home/${USER}/Hullbot_bag_files"  # Replace with the path to your ROS bags
+BAG2VID_SRC="/home/${USER}/rosbags"  # Replace with the path to your ROS bags
 
 # Add bag2vid script to bashrc
 echo "Adding bag2vid docker run alias to bashrc"
@@ -25,9 +25,9 @@ echo "    docker run -it --rm \\" >> ~/.bashrc
 echo "    --name bag2vid \\" >> ~/.bashrc
 echo "    --env DISPLAY=${DISPLAY} \\" >> ~/.bashrc
 echo "    --volume /tmp/.X11-unix:/tmp/.X11-unix \\" >> ~/.bashrc
-echo "    --volume \${BAG2VID_SRC}:/home/user/rosbags \\" >> ~/.bashrc
+echo "    --volume \${BAG2VID_SRC}:/home/ubuntu/rosbags \\" >> ~/.bashrc
 echo "    --network host \\" >> ~/.bashrc
 echo "    --privileged \\" >> ~/.bashrc
 echo "    \${BAG2VID_IMAGE} \\" >> ~/.bashrc
-echo "    bash -c \"source /opt/ros/melodic/setup.bash && rosrun bag2vid bag2vid_gui\"" >> ~/.bashrc
+echo "    bash -c \"source /opt/ros/jazzy/setup.bash && ros2 run bag2vid bag2vid_gui\"" >> ~/.bashrc
 echo "}" >> ~/.bashrc

--- a/bag2vid/src/backend/Extractor.cpp
+++ b/bag2vid/src/backend/Extractor.cpp
@@ -9,19 +9,27 @@ bool Extractor::loadBag(const std::string& bag_file)
     // Open the bag file
     try
     {
-        bag_.open(bag_file, rosbag::bagmode::Read);
+        reader_ = std::make_unique<rosbag2_cpp::Reader>();
+        rosbag2_storage::StorageOptions storage_options;
+        storage_options.uri = bag_file;
+        storage_options.storage_id = "";  // auto-detect format (mcap, sqlite3, etc.)
+
+        bag_file_ = bag_file;
+        reader_->open(storage_options);
+
         // Find the image topics in the bag
-        rosbag::View view(bag_);
-        for (const rosbag::ConnectionInfo* info : view.getConnections())
+        auto topics_and_types = reader_->get_all_topics_and_types();
+        for (const auto& topic_info : topics_and_types)
         {
-            if (info->datatype == "sensor_msgs/Image" || info->datatype == "sensor_msgs/CompressedImage")
+            if (topic_info.type == "sensor_msgs/msg/Image" || topic_info.type == "sensor_msgs/msg/CompressedImage")
             {
-                std::cout << "Found topic: " << info->topic << std::endl;
-                image_topics_.push_back(info->topic);
+                std::cout << "Found topic: " << topic_info.name << std::endl;
+                image_topics_.push_back(topic_info.name);
+                topic_type_map_[topic_info.name] = topic_info.type;
             }
         }
     }
-    catch (rosbag::BagIOException& e)
+    catch (const std::exception& e)
     {
         std::cerr << "Error opening bag file: " << e.what() << std::endl;
         return false;
@@ -33,9 +41,11 @@ bool Extractor::loadBag(const std::string& bag_file)
 void Extractor::closeBag()
 {
     // Close the bag file and clear the image data
-    bag_.close();
+    reader_.reset();
     image_data_.clear();
     image_topics_.clear();
+    topic_type_map_.clear();
+    camera_topic_map_.clear();
 }
 
 std::vector<std::string> Extractor::getImageTopics()
@@ -43,7 +53,17 @@ std::vector<std::string> Extractor::getImageTopics()
     return image_topics_;
 }
 
-std::vector<std::shared_ptr<rosbag::MessageInstance>> Extractor::extractMessages(const std::string& topic, const std::string& camera_name)
+std::string Extractor::getTopicType(const std::string& topic)
+{
+    auto it = topic_type_map_.find(topic);
+    if (it != topic_type_map_.end())
+    {
+        return it->second;
+    }
+    return "";
+}
+
+std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> Extractor::extractMessages(const std::string& topic, const std::string& camera_name)
 {
     // Check if we have already extracted messages for this topic
     if (image_data_.find(camera_name) != image_data_.end())
@@ -52,31 +72,73 @@ std::vector<std::shared_ptr<rosbag::MessageInstance>> Extractor::extractMessages
         return image_data_.at(camera_name);
     }
 
-    std::vector<std::shared_ptr<rosbag::MessageInstance>> messages;
-    
-    // Get the list of topics in the bag
-    std::vector<std::string> topics;
-    topics.push_back(topic);
+    std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages;
 
-    // Create a view for the topic
-    rosbag::View view(bag_, rosbag::TopicQuery(topics));
+    // Re-open the reader to reset the iterator position
+    rosbag2_storage::StorageOptions storage_options;
+    storage_options.uri = bag_file_;
+    storage_options.storage_id = "";
 
-    // Get begin and end times
-    bag_start_time_ = view.getBeginTime();
-    bag_end_time_ = view.getEndTime();
-    std::cout << "Start time: " << bag_start_time_ << std::endl;
-    std::cout << "End time: " << bag_end_time_ << std::endl;
+    auto topic_reader = std::make_unique<rosbag2_cpp::Reader>();
+    topic_reader->open(storage_options);
+
+    // Set filter to only read this topic
+    rosbag2_storage::StorageFilter filter;
+    filter.topics.push_back(topic);
+    topic_reader->set_filter(filter);
+
+    bool first_msg = true;
 
     // Extract the messages
-    for (const rosbag::MessageInstance& m : view)
+    while (topic_reader->has_next())
     {
-        messages.push_back(std::make_shared<rosbag::MessageInstance>(m));
+        auto msg = topic_reader->read_next();
+
+        double timestamp_sec = static_cast<double>(msg->recv_timestamp) / 1e9;
+
+        if (first_msg)
+        {
+            bag_start_time_sec_ = timestamp_sec;
+            first_msg = false;
+        }
+        bag_end_time_sec_ = timestamp_sec;
+
+        messages.push_back(msg);
     }
+
+    std::cout << "Start time: " << bag_start_time_sec_ << std::endl;
+    std::cout << "End time: " << bag_end_time_sec_ << std::endl;
 
     // Add messages to the image_data_ map
     image_data_[camera_name] = messages;
+    camera_topic_map_[camera_name] = topic;
 
     return messages;
+}
+
+cv::Mat Extractor::deserializeToImage(const bag2vid::MessageInstancePtr& msg, const std::string& type_str)
+{
+    rclcpp::SerializedMessage serialized_msg(*msg->serialized_data);
+
+    if (type_str == "sensor_msgs/msg/CompressedImage")
+    {
+        sensor_msgs::msg::CompressedImage ros_compressed;
+        rclcpp::Serialization<sensor_msgs::msg::CompressedImage> serializer;
+        serializer.deserialize_message(&serialized_msg, &ros_compressed);
+        return cv_bridge::toCvCopy(ros_compressed)->image;
+    }
+    else if (type_str == "sensor_msgs/msg/Image")
+    {
+        sensor_msgs::msg::Image ros_image;
+        rclcpp::Serialization<sensor_msgs::msg::Image> serializer;
+        serializer.deserialize_message(&serialized_msg, &ros_image);
+        return cv_bridge::toCvCopy(ros_image)->image;
+    }
+    else
+    {
+        std::cerr << "Unsupported image type: " << type_str << std::endl;
+        return cv::Mat();
+    }
 }
 
 bool Extractor::captureScreenshot(const std::string& camera_name, const int &frame_id, const std::string& image_file)
@@ -88,21 +150,13 @@ bool Extractor::captureScreenshot(const std::string& camera_name, const int &fra
         return false;
     }
 
-    std::string image_type = image_data_.at(camera_name).at(frame_id)->getDataType();
+    // Look up the message type from the topic
+    std::string image_type = getTopicType(camera_topic_map_[camera_name]);
     std::cout << "Image type: " << image_type << std::endl;
 
-    cv::Mat image;
-    if (image_type == "sensor_msgs/CompressedImage")
+    cv::Mat image = deserializeToImage(image_data_.at(camera_name).at(frame_id), image_type);
+    if (image.empty())
     {
-        image = cv_bridge::toCvCopy(image_data_.at(camera_name).at(frame_id)->instantiate<sensor_msgs::CompressedImage>())->image;
-    }
-    else if (image_type == "sensor_msgs/Image")
-    {
-        image = cv_bridge::toCvCopy(image_data_.at(camera_name).at(frame_id)->instantiate<sensor_msgs::Image>())->image;
-    }
-    else
-    {
-        std::cerr << "Unsupported image type: " << image_type << std::endl;
         return false;
     }
 
@@ -119,7 +173,7 @@ bool Extractor::captureScreenshot(const std::string& camera_name, const int &fra
     return true;
 }
 
-bool Extractor::writeVideo(const std::string& camera_name, const ros::Time& start_time, const ros::Time& end_time, const std::string& video_file)
+bool Extractor::writeVideo(const std::string& camera_name, const double& start_time, const double& end_time, const std::string& video_file)
 {
     // Write frames with timestamps start_time <= t < end_time to a video file
     std::cout << "Writing video for topic: " << camera_name << std::endl;
@@ -131,29 +185,20 @@ bool Extractor::writeVideo(const std::string& camera_name, const ros::Time& star
         return false;
     }
 
-    // Get image type from first image
-    std::string image_type = image_data_.at(camera_name).front()->getDataType();
+    // Look up the message type from the topic
+    std::string image_type = getTopicType(camera_topic_map_[camera_name]);
     std::cout << "Image type: " << image_type << std::endl;
 
-    // Get image size from first image.  Use image_type to determine how to convert to cv::Mat
-    cv::Mat first_image;
-    if (image_type == "sensor_msgs/CompressedImage")
+    // Get image size from first image
+    cv::Mat first_image = deserializeToImage(image_data_.at(camera_name).front(), image_type);
+    if (first_image.empty())
     {
-        first_image = cv_bridge::toCvCopy(image_data_.at(camera_name).front()->instantiate<sensor_msgs::CompressedImage>())->image;
-    }
-    else if (image_type == "sensor_msgs/Image")
-    {
-        first_image = cv_bridge::toCvCopy(image_data_.at(camera_name).front()->instantiate<sensor_msgs::Image>())->image;
-    }
-    else
-    {
-        std::cerr << "Unsupported image type: " << image_type << std::endl;
         return false;
     }
     cv::Size image_size(first_image.cols, first_image.rows);
     std::cout << "Image size: " << image_size << std::endl;
-    
-    // Open the video writer.  Write to .mp4 file with H265 codec
+
+    // Open the video writer.  Write to .mp4 file with H264 codec
     video_writer_.open(video_file, cv::VideoWriter::fourcc('a', 'v', 'c', '1'), 30, image_size);
     std::cout << "Video writer opened" << std::endl;
 
@@ -162,11 +207,12 @@ bool Extractor::writeVideo(const std::string& camera_name, const ros::Time& star
     // Get number of frames between start_time and end_time
     for (const auto& msg : image_data_.at(camera_name))
     {
-        if (msg->getTime() > end_time)
+        double msg_time = static_cast<double>(msg->recv_timestamp) / 1e9;
+        if (msg_time > end_time)
         {
             break;
         }
-        else if (msg->getTime() >= start_time)
+        else if (msg_time >= start_time)
         {
             total++;
         }
@@ -175,25 +221,19 @@ bool Extractor::writeVideo(const std::string& camera_name, const ros::Time& star
 
     for (const auto& msg : image_data_.at(camera_name))
     {
+        double msg_time = static_cast<double>(msg->recv_timestamp) / 1e9;
+
         // Check if message is within the time range.
         // If start_time == end_time, write all frames
-        if (msg->getTime() >= start_time && msg->getTime() < end_time || start_time == end_time)
+        if (msg_time >= start_time && msg_time < end_time || start_time == end_time)
         {
             // Convert the message to an image
-            cv::Mat image;
-            if (image_type == "sensor_msgs/CompressedImage")
+            cv::Mat image = deserializeToImage(msg, image_type);
+            if (image.empty())
             {
-                image = cv_bridge::toCvCopy(msg->instantiate<sensor_msgs::CompressedImage>())->image;
-            }
-            else if (image_type == "sensor_msgs/Image")
-            {
-                image = cv_bridge::toCvCopy(msg->instantiate<sensor_msgs::Image>())->image;
-            }
-            else
-            {
-                std::cerr << "Unsupported image type: " << image_type << std::endl;
                 return false;
             }
+
             // Write frame to video
             video_writer_.write(image);
             count++;

--- a/bag2vid/src/frontend/Timeline.cpp
+++ b/bag2vid/src/frontend/Timeline.cpp
@@ -79,7 +79,7 @@ void TimelineWidget::paintEvent(QPaintEvent *event)
 
 void TimelineWidget::mousePressEvent(QMouseEvent *event)
 {
-    int mouseX = event->x();
+    int mouseX = static_cast<int>(event->position().x());
 
     // Check if mouse press is on start marker
     int startMarkerX = (start_time_ / duration_) * (width() - 20) + 10;
@@ -102,13 +102,13 @@ void TimelineWidget::mousePressEvent(QMouseEvent *event)
 
 void TimelineWidget::mouseMoveEvent(QMouseEvent* event) {
     if (dragging_start_) {
-        updateMarkerPosition(start_time_, event->x());
+        updateMarkerPosition(start_time_, static_cast<int>(event->position().x()));
         update();
     } else if (dragging_end_) {
-        updateMarkerPosition(end_time_, event->x());
+        updateMarkerPosition(end_time_, static_cast<int>(event->position().x()));
         update();
     } else if (dragging_timeline_) {
-        updateMarkerPosition(current_time_, event->x());
+        updateMarkerPosition(current_time_, static_cast<int>(event->position().x()));
         update();
         emit currentTimeChanged(current_time_);
     }

--- a/bag2vid/src/frontend/VideoPlayer.cpp
+++ b/bag2vid/src/frontend/VideoPlayer.cpp
@@ -4,8 +4,6 @@
 #include <QImage>
 #include <QThread>
 
-#include <cv_bridge/cv_bridge.h>
-
 
 VideoPlayer::VideoPlayer(QObject *parent) :
     QObject(parent),
@@ -24,9 +22,10 @@ VideoPlayer::~VideoPlayer()
 void VideoPlayer::seekToTime(double time)
 {
     // Set current frame to the first frame after the time
-    for (int i = 0; i < messages_.size(); i++)
+    for (size_t i = 0; i < messages_.size(); i++)
     {
-        if (messages_[i]->getTime().toSec() >= time + start_time_)
+        double msg_time = static_cast<double>(messages_[i]->recv_timestamp) / 1e9;
+        if (msg_time >= time + start_time_)
         {
             current_frame_ = i;
             break;
@@ -34,19 +33,35 @@ void VideoPlayer::seekToTime(double time)
     }
 }
 
+void VideoPlayer::processFrame(int index)
+{
+    if (index < 0 || index >= static_cast<int>(messages_.size()))
+        return;
+
+    rclcpp::SerializedMessage serialized_msg(*messages_[index]->serialized_data);
+
+    if (message_type_ == "sensor_msgs/msg/Image")
+    {
+        auto ros_image = std::make_shared<sensor_msgs::msg::Image>();
+        rclcpp::Serialization<sensor_msgs::msg::Image> serializer;
+        serializer.deserialize_message(&serialized_msg, ros_image.get());
+        processImageMessage(ros_image);
+    }
+    else if (message_type_ == "sensor_msgs/msg/CompressedImage")
+    {
+        auto ros_compressed = std::make_shared<sensor_msgs::msg::CompressedImage>();
+        rclcpp::Serialization<sensor_msgs::msg::CompressedImage> serializer;
+        serializer.deserialize_message(&serialized_msg, ros_compressed.get());
+        processCompressedImageMessage(ros_compressed);
+    }
+}
+
 void VideoPlayer::playback()
 {
-    if (is_playing_ && current_frame_ < messages_.size())
+    if (is_playing_ && current_frame_ < static_cast<int>(messages_.size()))
     {
-        if (messages_[current_frame_]->isType<sensor_msgs::Image>())
-        {
-            processImageMessage(messages_[current_frame_]->instantiate<sensor_msgs::Image>());
-        }
-        else if (messages_[current_frame_]->isType<sensor_msgs::CompressedImage>())
-        {
-            processCompressedImageMessage(messages_[current_frame_]->instantiate<sensor_msgs::CompressedImage>());
-        }
-        double frame_timestamp = messages_[current_frame_]->getTime().toSec();
+        processFrame(current_frame_);
+        double frame_timestamp = static_cast<double>(messages_[current_frame_]->recv_timestamp) / 1e9;
         emit currentTimestamp(frame_timestamp - start_time_);
         current_frame_++;
     }
@@ -72,59 +87,40 @@ void VideoPlayer::seekBackward()
     if (current_frame_ > 0)
     {
         current_frame_--;
-        if (messages_[current_frame_]->isType<sensor_msgs::Image>())
-        {
-            processImageMessage(messages_[current_frame_]->instantiate<sensor_msgs::Image>());
-        }
-        else if (messages_[current_frame_]->isType<sensor_msgs::CompressedImage>())
-        {
-            processCompressedImageMessage(messages_[current_frame_]->instantiate<sensor_msgs::CompressedImage>());
-        }
-        double frame_timestamp = messages_[current_frame_]->getTime().toSec();
+        processFrame(current_frame_);
+        double frame_timestamp = static_cast<double>(messages_[current_frame_]->recv_timestamp) / 1e9;
         emit currentTimestamp(frame_timestamp - start_time_);
     }
 }
 
 void VideoPlayer::seekForward()
 {
-    if (current_frame_ < messages_.size())
+    if (current_frame_ < static_cast<int>(messages_.size()))
     {
-        if (messages_[current_frame_]->isType<sensor_msgs::Image>())
-        {
-            processImageMessage(messages_[current_frame_]->instantiate<sensor_msgs::Image>());
-        }
-        else if (messages_[current_frame_]->isType<sensor_msgs::CompressedImage>())
-        {
-            processCompressedImageMessage(messages_[current_frame_]->instantiate<sensor_msgs::CompressedImage>());
-        }
-        double frame_timestamp = messages_[current_frame_]->getTime().toSec();
+        processFrame(current_frame_);
+        double frame_timestamp = static_cast<double>(messages_[current_frame_]->recv_timestamp) / 1e9;
         emit currentTimestamp(frame_timestamp - start_time_);
         current_frame_++;
     }
 }
 
-void VideoPlayer::loadMessages(std::vector<std::shared_ptr<rosbag::MessageInstance>> messages)
+void VideoPlayer::loadMessages(std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages,
+                                const std::string& message_type)
 {
     current_frame_ = 0;
     messages_ = messages;
-    start_time_ = messages[0]->getTime().toSec();
-    end_time_ = messages[messages.size() - 1]->getTime().toSec();
-    // Process first frame
-    if (messages_.size() > 0)
+    message_type_ = message_type;
+    if (messages_.empty())
     {
-        // Process first frame
-        if (messages_[0]->isType<sensor_msgs::Image>())
-        {
-            processImageMessage(messages_[0]->instantiate<sensor_msgs::Image>());
-        }
-        else if (messages_[0]->isType<sensor_msgs::CompressedImage>())
-        {
-            processCompressedImageMessage(messages_[0]->instantiate<sensor_msgs::CompressedImage>());
-        }
+        return;
     }
+    start_time_ = static_cast<double>(messages_[0]->recv_timestamp) / 1e9;
+    end_time_ = static_cast<double>(messages_[messages_.size() - 1]->recv_timestamp) / 1e9;
+    // Process first frame
+    processFrame(0);
 }
 
-void VideoPlayer::processImageMessage(const sensor_msgs::Image::ConstPtr &msg)
+void VideoPlayer::processImageMessage(const sensor_msgs::msg::Image::SharedPtr &msg)
 {
     if (msg != nullptr)
     {
@@ -132,7 +128,7 @@ void VideoPlayer::processImageMessage(const sensor_msgs::Image::ConstPtr &msg)
     }
 }
 
-void VideoPlayer::processCompressedImageMessage(const sensor_msgs::CompressedImage::ConstPtr &msg)
+void VideoPlayer::processCompressedImageMessage(const sensor_msgs::msg::CompressedImage::SharedPtr &msg)
 {
     if (msg != nullptr)
     {

--- a/bag2vid/src/frontend/Visualiser.cpp
+++ b/bag2vid/src/frontend/Visualiser.cpp
@@ -25,7 +25,7 @@ Visualiser::Visualiser(QWidget *parent) :
     connect(load_bag_button_, &QPushButton::clicked, this, &Visualiser::loadBag);
     connect(play_pause_button_, &QPushButton::clicked, this, &Visualiser::togglePlayPause);
     connect(extract_video_button_, &QPushButton::clicked, this, &Visualiser::extractVideo);
-    connect(topic_dropdown_, SIGNAL(currentIndexChanged(int)), this, SLOT(updateTopicDropdown()));
+    connect(topic_dropdown_, &QComboBox::currentIndexChanged, this, &Visualiser::updateTopicDropdown);
     connect(capture_screenshot_button_, &QPushButton::clicked, this, &Visualiser::captureScreenshot);
 
     connect(video_player_, &VideoPlayer::newFrame, [this](const QImage& frame)
@@ -36,7 +36,7 @@ Visualiser::Visualiser(QWidget *parent) :
         image_label_->setPixmap(QPixmap::fromImage(resized_frame));
     });
 
-    connect(video_player_, &VideoPlayer::currentTimestamp, [this](float time)
+    connect(video_player_, &VideoPlayer::currentTimestamp, [this](double time)
     {
         // std::cout << "Current time: " << time << std::endl;
         timeline_widget_->setCurrentTime(time);
@@ -148,10 +148,10 @@ void Visualiser::resizeEvent(QResizeEvent *event)
 {
     QWidget::resizeEvent(event);
 
-    if (image_label_->pixmap() != nullptr && !image_label_->pixmap()->isNull())
+    if (!image_label_->pixmap().isNull())
     {
         QSize label_size = image_label_->size();
-        QImage resized_frame = image_label_->pixmap()->toImage().scaled(label_size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
+        QImage resized_frame = image_label_->pixmap().toImage().scaled(label_size, Qt::KeepAspectRatio, Qt::SmoothTransformation);
         image_label_->setPixmap(QPixmap::fromImage(resized_frame));
     }
 }
@@ -167,7 +167,7 @@ void Visualiser::loadBag()
     }
 
     // Select rosbag file
-    QString rosbag_path = QFileDialog::getOpenFileName(this, "Open rosbag", QDir::homePath(), "Ros bag files (*.bag)");
+    QString rosbag_path = QFileDialog::getOpenFileName(this, "Open rosbag", QDir::homePath(), "Rosbag files (*.bag *.mcap)");
 
     // No file specified, cancel load
     if (rosbag_path.isEmpty())
@@ -218,12 +218,16 @@ void Visualiser::updateTopicDropdown()
     // Load messages for the selected topic
     // camera name is first part of topic name (eg. /camera_2/image_raw_relay/compressed -> camera_2)
     std::string camera_name = current_topic.substr(1, current_topic.find("/", 1) - 1);
-    
+
     std::cout << "Extracting messages for camera: " << camera_name << std::endl;
-    std::vector<std::shared_ptr<rosbag::MessageInstance>> messages =
+    std::vector<bag2vid::MessageInstancePtr> messages =
       extractor_->extractMessages(topic_dropdown_->currentText().toStdString(), camera_name);
+
+    // Look up the message type for this topic
+    std::string message_type = extractor_->getTopicType(current_topic);
+
     // Load messages into video player
-    video_player_->loadMessages(messages);
+    video_player_->loadMessages(messages, message_type);
     std::cout << "Messages extracted" << std::endl;
 }
 
@@ -291,7 +295,7 @@ void Visualiser::extractVideo()
         updateProgressBar(progress);
     });
 
-    if (extractor_->writeVideo(camera_name, ros::Time(start_time), ros::Time(end_time), video_path.toStdString()))
+    if (extractor_->writeVideo(camera_name, start_time, end_time, video_path.toStdString()))
     {
         std::cout << "Video extracted successfully" << std::endl;
         extraction_progress_bar_->setValue(100);

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,8 +1,7 @@
-# Docker compose file for ubuntu 18.04 ros melodic
-version: '3.9'
+# Docker compose file for Ubuntu 24.04 ROS 2 Jazzy
 
 services:
-  ros_melodic:
+  ros_jazzy:
     build:
       context: .
       dockerfile: Dockerfile
@@ -10,7 +9,7 @@ services:
         ROSBAG_SRC_FOLDER: ${BAG2VID_SRC}
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
-      - ${BAG2VID_SRC}:/home/user/rosbags
+      - ${BAG2VID_SRC}:/home/ubuntu/rosbags
     command: /bin/bash
     environment:
       - DISPLAY=${DISPLAY}


### PR DESCRIPTION
  ## Summary
  - Port from ROS 1 Melodic to ROS 2 Jazzy
  - Migrate build system from catkin to ament_cmake
  - Upgrade from Qt5 to Qt6
  - Replace rosbag with rosbag2_cpp for MCAP bag support
  - Update Docker from Ubuntu 18.04 (Melodic) to Ubuntu 24.04 (Jazzy)

  ## Changes
  - **Backend**: rosbag::Bag → rosbag2_cpp::Reader, message deserialization via rclcpp::Serialization
  - **Frontend**: Qt6 API updates (mouse events, pixmap, modern connect syntax), file dialog supports .bag and .mcap
  - **Build**: CMakeLists.txt rewritten for ament + Qt6, package.xml format 3
  - **Docker**: New base image, colcon build, ffmpeg/x264 for video encoding
  - **Entry points**: Removed unused ros::init, updated to ros2 run

  ## Test plan
  - [x] Docker image builds successfully
  - [x] App opens and loads MCAP bag
  - [x] Video playback works
  - [x] Video extraction produces .mp4
  - [x] Screenshot capture works
  - [x] Timeline markers are draggable
