### PR TITLE
Add PlaybackClock for timestamp faithful playback

### DIFF
--- a/bag2vid/CMakeLists.txt
+++ b/bag2vid/CMakeLists.txt
@@ -26,9 +26,11 @@ add_library(${PROJECT_NAME}_lib SHARED
   src/frontend/Visualiser.cpp
   src/frontend/Timeline.cpp
   src/frontend/VideoPlayer.cpp
+  src/frontend/PlaybackClock.cpp
   include/bag2vid/frontend/Visualiser.hpp
   include/bag2vid/frontend/Timeline.hpp
   include/bag2vid/frontend/VideoPlayer.hpp
+  include/bag2vid/frontend/PlaybackClock.hpp
   resources/resources.qrc
 )
 

--- a/bag2vid/include/bag2vid/frontend/PlaybackClock.hpp
+++ b/bag2vid/include/bag2vid/frontend/PlaybackClock.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <QObject>
+#include <QTimer>
+
+namespace bag2vid
+{
+
+/**
+ * @brief Master playback clock.
+ *
+ * Owns the playback time, rate and play/pause state. Emits tick() on a
+ * regular cadence so subscribers (video players, timeline, etc.) can render
+ * the content appropriate for the current time.
+ *
+ * Times are bag-relative (0.0 = bag start).
+ */
+class PlaybackClock : public QObject
+{
+    Q_OBJECT
+
+public:
+    explicit PlaybackClock(QObject *parent = nullptr);
+    ~PlaybackClock() override = default;
+
+    inline double getCurrentTime() const { return current_time_; }
+    inline double getPlaybackRate() const { return playback_rate_; }
+    inline bool isPlaying() const { return is_playing_; }
+
+public slots:
+    void play();
+    void pause();
+    void seek(double time);
+    void setPlaybackRate(double rate);
+    void setRange(double start_time, double end_time);
+
+signals:
+    void tick(double time);
+    void finished();
+
+private slots:
+    void onTick();
+
+private:
+    QTimer timer_;
+
+    bool is_playing_;
+
+    // Relative playback time within bag recording (>= 0.0)
+    double current_time_;
+
+    // Start and end timestamps of bag (seconds since epoch)
+    double start_timestamp_;
+    double end_timestamp_;
+    
+    // Duration of the bag in seconds (end - start timestamps)
+    double duration_;
+
+    // Playback rate multiplier
+    // for example: 0.5 = half speed, 1.0 = real time, 2.0 = 2x playback speed
+    double playback_rate_ = 1.0;
+
+    // PlaybackClock rate - use 60Hz, typical monitor refresh rate
+    static constexpr int kClockTickRate = 60;
+    static constexpr int kTickIntervalMs = 1000 / kClockTickRate;
+};
+
+} // namespace bag2vid

--- a/bag2vid/include/bag2vid/frontend/VideoPlayer.hpp
+++ b/bag2vid/include/bag2vid/frontend/VideoPlayer.hpp
@@ -1,5 +1,3 @@
-
-
 #pragma once
 
 #include <rosbag2_storage/serialized_bag_message.hpp>
@@ -10,7 +8,6 @@
 
 #include <QImage>
 #include <QObject>
-#include <QTimer>
 
 class VideoPlayer : public QObject
 {
@@ -37,43 +34,34 @@ public:
      */
     int getCurrentFrameId() const { return current_frame_; }
 
+    /**
+     * @brief Get the bag-relative timestamp of the previous frame, or -1 if none.
+     */
+    double prevFrameTime() const;
+
+    /**
+     * @brief Get the bag-relative timestamp of the next frame, or -1 if none.
+     */
+    double nextFrameTime() const;
+
 public slots:
     /**
-     * @brief Move the video player to the specified time (in seconds).
-     * First frame of the rosbag is at time 0.
+     * @brief Render the frame appropriate for the given bag-relative time.
      *
-     * @param time
+     * @param time Seconds since bag start.
      */
-    void seekToTime(double time);
-
-    /**
-     * @brief Start playing the video.
-     */
-    void play();
-
-    /**
-     * @brief Pause the video.
-     */
-    void pause();
+    void onClockTick(double time);
 
     /**
      * @brief Load messages from a rosbag.
      *
      * @param messages Vector of shared pointers to serialized bag messages.
      * @param message_type The ROS message type string (e.g. "sensor_msgs/msg/Image").
+     * @param bag_start_time Absolute time (seconds) that corresponds to bag-relative t=0.
      */
     void loadMessages(std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages,
-                      const std::string& message_type);
-
-    /**
-     * @brief Move the video player to the previous frame.
-     */
-    void seekBackward();
-
-    /**
-     * @brief Move the video player to the next frame.
-     */
-    void seekForward();
+                      const std::string& message_type,
+                      double bag_start_time);
 
 signals:
     /**
@@ -83,38 +71,20 @@ signals:
      */
     void newFrame(const QImage &frame);
 
-    /**
-     * @brief Set the timestamp of the current frame.
-     *
-     * @param time
-     * @return * void
-     */
-    void currentTimestamp(double time);
-
-    /**
-     * @brief Signal emitted when the video has finished playing.
-     *
-     */
-    void finishedPlaying();
-
-private slots:
-    void playback();
-
 private:
-    //  Flag to indicate if the video is playing
-    bool is_playing_;
-    //  Current frame iterator
+    // Current frame index into messages_
     int current_frame_;
-    // Time of start-point marker of video extraction
-    double start_time_;
-    // Time of end-point marker of video extraction
-    double end_time_;
-    // Timer for playback
-    QTimer playback_timer_;
+    // Absolute time (seconds) that corresponds to bag-relative t=0
+    double bag_start_time_;
     // Vector of shared pointers to serialized bag messages
     std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages_;
     // The ROS message type string for this set of messages
     std::string message_type_;
+
+    /**
+     * @brief Bag-relative timestamp of the message at the given index.
+     */
+    double messageTime(int index) const;
 
     /**
      * @brief Process and emit a frame from the message at the given index.

--- a/bag2vid/include/bag2vid/frontend/Visualiser.hpp
+++ b/bag2vid/include/bag2vid/frontend/Visualiser.hpp
@@ -19,6 +19,7 @@
 #include <QProgressBar>
 
 #include <bag2vid/backend/Extractor.hpp>
+#include <bag2vid/frontend/PlaybackClock.hpp>
 #include <bag2vid/frontend/Timeline.hpp>
 #include <bag2vid/frontend/VideoPlayer.hpp>
 
@@ -98,10 +99,10 @@ private:
     TimelineWidget* timeline_widget_;
     // Video player for displaying the video preview
     VideoPlayer* video_player_;
+    // Master playback clock driving video player and timeline
+    PlaybackClock* clock_;
     QThread* thread_;
     QLabel* image_label_;
-
-    bool is_playing_;
 
     /**
      * @brief Set up the GUI elements.

--- a/bag2vid/src/frontend/PlaybackClock.cpp
+++ b/bag2vid/src/frontend/PlaybackClock.cpp
@@ -1,0 +1,81 @@
+#include "bag2vid/frontend/PlaybackClock.hpp"
+
+#include <algorithm>
+
+namespace bag2vid
+{
+
+PlaybackClock::PlaybackClock(QObject *parent) :
+    QObject(parent),
+    is_playing_(false),
+    current_time_(0.0),
+    start_timestamp_(0.0),
+    end_timestamp_(0.0),
+    duration_(0.0),
+    playback_rate_(1.0)
+{
+    timer_.setTimerType(Qt::PreciseTimer);
+    connect(&timer_, &QTimer::timeout, this, &PlaybackClock::onTick);
+}
+
+void PlaybackClock::play()
+{
+    if (is_playing_)
+    {
+        return;
+    }
+    if (duration_ <= 0.0)
+    {
+        return;
+    }
+    if (current_time_ >= duration_)
+    {
+        current_time_ = 0.0;
+        emit tick(current_time_);
+    }
+    is_playing_ = true;
+    timer_.start(kTickIntervalMs);
+}
+
+void PlaybackClock::pause()
+{
+    is_playing_ = false;
+    timer_.stop();
+}
+
+void PlaybackClock::seek(double time)
+{
+    current_time_ = std::clamp(time, 0.0, duration_);
+    emit tick(current_time_);
+}
+
+void PlaybackClock::setPlaybackRate(double rate)
+{
+    playback_rate_ = rate;
+}
+
+void PlaybackClock::setRange(double start_time, double end_time)
+{
+    start_timestamp_ = start_time;
+    end_timestamp_ = end_time;
+    duration_ = end_time - start_time;
+    current_time_ = 0.0;
+    emit tick(current_time_);
+}
+
+void PlaybackClock::onTick()
+{
+    current_time_ += (kTickIntervalMs / 1000.0) * playback_rate_;
+    if (current_time_ >= duration_)
+    {
+        current_time_ = duration_;
+        is_playing_ = false;
+        timer_.stop();
+        emit tick(current_time_);
+        emit finished();
+        return;
+    }
+    emit tick(current_time_);
+}
+
+} // namespace bag2vid

--- a/bag2vid/src/frontend/VideoPlayer.cpp
+++ b/bag2vid/src/frontend/VideoPlayer.cpp
@@ -1,35 +1,62 @@
 #include "bag2vid/frontend/VideoPlayer.hpp"
 
-#include <QDebug>
 #include <QImage>
-#include <QThread>
-
 
 VideoPlayer::VideoPlayer(QObject *parent) :
     QObject(parent),
-    is_playing_(false),
     current_frame_(0),
-    start_time_(0.0),
-    end_time_(1.0)
+    bag_start_time_(0.0)
 {
-    connect(&playback_timer_, &QTimer::timeout, this, &VideoPlayer::playback);
 }
 
 VideoPlayer::~VideoPlayer()
 {
 }
 
-void VideoPlayer::seekToTime(double time)
+double VideoPlayer::messageTime(int index) const
 {
-    // Set current frame to the first frame after the time
-    for (size_t i = 0; i < messages_.size(); i++)
+    if (index < 0 || index >= static_cast<int>(messages_.size()))
     {
-        double msg_time = static_cast<double>(messages_[i]->recv_timestamp) / 1e9;
-        if (msg_time >= time + start_time_)
-        {
-            current_frame_ = i;
-            break;
-        }
+        return -1.0;
+    }
+    return static_cast<double>(messages_[index]->recv_timestamp) / 1e9 - bag_start_time_;
+}
+
+double VideoPlayer::prevFrameTime() const
+{
+    return messageTime(current_frame_ - 1);
+}
+
+double VideoPlayer::nextFrameTime() const
+{
+    return messageTime(current_frame_ + 1);
+}
+
+void VideoPlayer::onClockTick(double time)
+{
+    if (messages_.empty())
+    {
+        return;
+    }
+
+    int new_frame = current_frame_;
+
+    // Walk forward while the next frame is still at or before `time`
+    while (new_frame + 1 < static_cast<int>(messages_.size()) &&
+           messageTime(new_frame + 1) <= time)
+    {
+        new_frame++;
+    }
+    // Walk backward (seek) while the current frame is after `time`
+    while (new_frame > 0 && messageTime(new_frame) > time)
+    {
+        new_frame--;
+    }
+
+    if (new_frame != current_frame_)
+    {
+        current_frame_ = new_frame;
+        processFrame(current_frame_);
     }
 }
 
@@ -56,67 +83,18 @@ void VideoPlayer::processFrame(int index)
     }
 }
 
-void VideoPlayer::playback()
-{
-    if (is_playing_ && current_frame_ < static_cast<int>(messages_.size()))
-    {
-        processFrame(current_frame_);
-        double frame_timestamp = static_cast<double>(messages_[current_frame_]->recv_timestamp) / 1e9;
-        emit currentTimestamp(frame_timestamp - start_time_);
-        current_frame_++;
-    }
-}
-
-void VideoPlayer::play()
-{
-    if (!is_playing_)
-    {
-        is_playing_ = true;
-        playback_timer_.start(1000 / 30); // 30 FPS
-    }
-}
-
-void VideoPlayer::pause()
-{
-    is_playing_ = false;
-    playback_timer_.stop();
-}
-
-void VideoPlayer::seekBackward()
-{
-    if (current_frame_ > 0)
-    {
-        current_frame_--;
-        processFrame(current_frame_);
-        double frame_timestamp = static_cast<double>(messages_[current_frame_]->recv_timestamp) / 1e9;
-        emit currentTimestamp(frame_timestamp - start_time_);
-    }
-}
-
-void VideoPlayer::seekForward()
-{
-    if (current_frame_ < static_cast<int>(messages_.size()))
-    {
-        processFrame(current_frame_);
-        double frame_timestamp = static_cast<double>(messages_[current_frame_]->recv_timestamp) / 1e9;
-        emit currentTimestamp(frame_timestamp - start_time_);
-        current_frame_++;
-    }
-}
-
 void VideoPlayer::loadMessages(std::vector<std::shared_ptr<rosbag2_storage::SerializedBagMessage>> messages,
-                                const std::string& message_type)
+                                const std::string& message_type,
+                                double bag_start_time)
 {
     current_frame_ = 0;
     messages_ = messages;
     message_type_ = message_type;
+    bag_start_time_ = bag_start_time;
     if (messages_.empty())
     {
         return;
     }
-    start_time_ = static_cast<double>(messages_[0]->recv_timestamp) / 1e9;
-    end_time_ = static_cast<double>(messages_[messages_.size() - 1]->recv_timestamp) / 1e9;
-    // Process first frame
     processFrame(0);
 }
 

--- a/bag2vid/src/frontend/Visualiser.cpp
+++ b/bag2vid/src/frontend/Visualiser.cpp
@@ -17,7 +17,6 @@ namespace bag2vid
 Visualiser::Visualiser(QWidget *parent) :
     QWidget(parent)
 {
-    is_playing_ = false;
     extractor_ = std::make_unique<Extractor>();
     setupUI();
 
@@ -36,17 +35,15 @@ Visualiser::Visualiser(QWidget *parent) :
         image_label_->setPixmap(QPixmap::fromImage(resized_frame));
     });
 
-    connect(video_player_, &VideoPlayer::currentTimestamp, [this](double time)
+    // Clock drives both the video player and the timeline playhead
+    connect(clock_, &PlaybackClock::tick, video_player_, &VideoPlayer::onClockTick);
+    connect(clock_, &PlaybackClock::tick, timeline_widget_, &TimelineWidget::setCurrentTime);
+    connect(clock_, &PlaybackClock::finished, this, [this]()
     {
-        // std::cout << "Current time: " << time << std::endl;
-        timeline_widget_->setCurrentTime(time);
+        play_pause_button_->setText("Play");
     });
 
-    connect(timeline_widget_, &TimelineWidget::currentTimeChanged, [this](double time)
-    {
-        // std::cout << "Seek to time: " << time << std::endl;
-        video_player_->seekToTime(time);
-    });
+    connect(timeline_widget_, &TimelineWidget::currentTimeChanged, clock_, &PlaybackClock::seek);
 }
 
 void Visualiser::setupUI()
@@ -71,6 +68,9 @@ void Visualiser::setupUI()
 
     // Set up the video widget
     video_player_ = new VideoPlayer(this);
+
+    // Set up the playback clock
+    clock_ = new PlaybackClock(this);
     image_label_ = new QLabel(this);
     image_label_->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     image_label_->setMinimumSize(320, 240);
@@ -135,12 +135,28 @@ void Visualiser::keyPressEvent(QKeyEvent *event)
     // Left moves current frame back 1 frame
     else if (event->key() == Qt::Key_Left)
     {
-        video_player_->seekBackward();
+        if (clock_->isPlaying())
+        {
+            togglePlayPause();
+        }
+        double t = video_player_->prevFrameTime();
+        if (t >= 0.0)
+        {
+            clock_->seek(t);
+        }
     }
     // Right arrow seeks forward 1 frame
     else if (event->key() == Qt::Key_Right)
     {
-        video_player_->seekForward();
+        if (clock_->isPlaying())
+        {
+            togglePlayPause();
+        }
+        double t = video_player_->nextFrameTime();
+        if (t >= 0.0)
+        {
+            clock_->seek(t);
+        }
     }
 }
 
@@ -161,7 +177,7 @@ void Visualiser::loadBag()
     std::cout << "Load Bag" << std::endl;
 
     // Pause video player if playing
-    if (is_playing_)
+    if (clock_->isPlaying())
     {
         togglePlayPause();
     }
@@ -192,11 +208,17 @@ void Visualiser::loadBag()
         {
             topic_dropdown_->addItem(QString::fromStdString(topic));
         }
-        // Set start and end time of timeline
-        timeline_widget_->setBagStartTime(extractor_->getBagStartTime());
-        timeline_widget_->setBagEndTime(extractor_->getBagEndTime());
+        // Populating the dropdown triggers updateTopicDropdown, which calls
+        // extractMessages as a side effect -- that's what actually populates
+        // bag_start_time_sec_ / bag_end_time_sec_ in the extractor. So we must
+        // read them out AFTER the dropdown is populated.
+        double bag_start = extractor_->getBagStartTime();
+        double bag_end = extractor_->getBagEndTime();
+        timeline_widget_->setBagStartTime(bag_start);
+        timeline_widget_->setBagEndTime(bag_end);
         timeline_widget_->setStartTime(0.0);
-        timeline_widget_->setEndTime(extractor_->getBagEndTime() - extractor_->getBagStartTime());
+        timeline_widget_->setEndTime(bag_end - bag_start);
+        clock_->setRange(bag_start, bag_end);
     }
     else
     {
@@ -227,25 +249,31 @@ void Visualiser::updateTopicDropdown()
     std::string message_type = extractor_->getTopicType(current_topic);
 
     // Load messages into video player
-    video_player_->loadMessages(messages, message_type);
+    video_player_->loadMessages(messages, message_type, extractor_->getBagStartTime());
+    // Re-render the frame for the current clock time so switching topics while
+    // paused shows the equivalent moment, not the first frame of the new topic.
+    video_player_->onClockTick(clock_->getCurrentTime());
     std::cout << "Messages extracted" << std::endl;
 }
 
 void Visualiser::togglePlayPause()
 {
-    if (is_playing_)
+    if (clock_->isPlaying())
     {
         std::cout << "Pause" << std::endl;
-        video_player_->pause();
+        clock_->pause();
         play_pause_button_->setText("Play");
     }
     else
     {
         std::cout << "Play" << std::endl;
-        video_player_->play();
-        play_pause_button_->setText("Pause");
+        clock_->play();
+        // play() is a no-op if no bag is loaded; only flip the label if it actually started
+        if (clock_->isPlaying())
+        {
+            play_pause_button_->setText("Pause");
+        }
     }
-    is_playing_ = !is_playing_;
 }
 
 void Visualiser::extractVideo()


### PR DESCRIPTION
- Implement a _PlaybackClock_ to enable playback at true recording rate
- Tracks current time within playback
- Clock drives VideoPlayer and timeline playhead from a single time source
- Emits tick signal at 60Hz to update frame and playhead  