### PR TITLE
Run video extraction on a worker thread

### DIFF
--- a/bag2vid/CMakeLists.txt
+++ b/bag2vid/CMakeLists.txt
@@ -18,7 +18,7 @@ find_package(cv_bridge REQUIRED)
 
 # System dependencies
 find_package(OpenCV REQUIRED)
-find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Multimedia MultimediaWidgets)
+find_package(Qt6 REQUIRED COMPONENTS Core Gui Widgets Multimedia MultimediaWidgets Concurrent)
 
 # Library
 add_library(${PROJECT_NAME}_lib SHARED
@@ -51,6 +51,7 @@ target_link_libraries(${PROJECT_NAME}_lib
   Qt6::Widgets
   Qt6::Multimedia
   Qt6::MultimediaWidgets
+  Qt6::Concurrent
 )
 
 # GUI executable

--- a/bag2vid/include/bag2vid/frontend/Visualiser.hpp
+++ b/bag2vid/include/bag2vid/frontend/Visualiser.hpp
@@ -127,7 +127,6 @@ private:
     VideoPlayer* video_player_;
     // Master playback clock driving video player and timeline
     PlaybackClock* clock_;
-    QThread* thread_;
     QLabel* image_label_;
 
     /**
@@ -141,5 +140,16 @@ private:
      *
      */
     void updateProgressBar(int progress);
+
+    /**
+     * @brief Kick off extraction on a worker thread.
+     *
+     * Disables controls that would mutate extractor_ state, runs writeVideo
+     * off-thread, and re-enables controls from the completion continuation.
+     */
+    void startExtraction(const std::string& camera_name,
+                         double start_time,
+                         double end_time,
+                         const std::string& video_path);
 };
 } // namespace bag2vid

--- a/bag2vid/src/frontend/Visualiser.cpp
+++ b/bag2vid/src/frontend/Visualiser.cpp
@@ -10,7 +10,7 @@
 #include <QPainter>
 #include <QMouseEvent>
 #include <QFileDialog>
-#include <QThread>
+#include <QtConcurrent>
 
 
 namespace bag2vid
@@ -347,22 +347,49 @@ void Visualiser::extractVideo()
         return;
     }
 
+    startExtraction(camera_name, start_time, end_time, video_path.toStdString());
+}
+
+void Visualiser::startExtraction(const std::string& camera_name,
+                                 double start_time,
+                                 double end_time,
+                                 const std::string& video_path)
+{
     extraction_progress_bar_->setValue(0);
-    // Set progress callback
+
+    // Progress fires from the worker; marshal back to the GUI thread before touching widgets
     extractor_->setProgressCallback([this](int progress)
     {
-        updateProgressBar(progress);
+        QMetaObject::invokeMethod(this, [this, progress]()
+        {
+            updateProgressBar(progress);
+        }, Qt::QueuedConnection);
     });
 
-    if (extractor_->writeVideo(camera_name, start_time, end_time, video_path.toStdString()))
+    // Block controls that would mutate extractor_ mid-run
+    extract_video_button_->setEnabled(false);
+    load_bag_button_->setEnabled(false);
+    topic_dropdown_->setEnabled(false);
+
+    // Capture by value: the worker outlives this function, so locals would dangle if captured by reference
+    QtConcurrent::run([this, camera_name, start_time, end_time, video_path]()
     {
-        std::cout << "Video extracted successfully" << std::endl;
-        extraction_progress_bar_->setValue(100);
-    }
-    else
+        return extractor_->writeVideo(camera_name, start_time, end_time, video_path);
+    }).then(this, [this](bool success)
     {
-        std::cout << "Failed to extract video" << std::endl;
-    }
+        if (success)
+        {
+            std::cout << "Video extracted successfully" << std::endl;
+            extraction_progress_bar_->setValue(100);
+        }
+        else
+        {
+            std::cout << "Failed to extract video" << std::endl;
+        }
+        extract_video_button_->setEnabled(true);
+        load_bag_button_->setEnabled(true);
+        topic_dropdown_->setEnabled(true);
+    });
 }
 
 void Visualiser::captureScreenshot()


### PR DESCRIPTION
- Use QtConcurrent to run run video extraction on a worker thread
- Separate writeVideo dispatch from extractVideo's input-gathering logic