### PR TITLE
Fix use-after-free crash when loading a second bag

### DIFF
--- a/bag2vid/src/frontend/Visualiser.cpp
+++ b/bag2vid/src/frontend/Visualiser.cpp
@@ -221,6 +221,10 @@ void Visualiser::loadBag()
     {
         return;
     }
+    // Release old shared_ptrs before resetting extractor_: their deleters
+    // reference Reader memory and must not outlive it.
+    video_player_->loadMessages({}, "", 0.0);
+
     // Reset extractor
     extractor_ = std::make_unique<Extractor>();
 


### PR DESCRIPTION
- Fix segfault when loading a second bag in the same session
- Root cause: rosbag2's Reader owns the deleters of the shared_ptrs it returns, so destroying the Reader while VideoPlayer still holds those shared_ptrs turns them into zombies that UAF on release
- Fix: clear VideoPlayer's messages before resetting the Extractor, so the old Reader is still alive when the deleters fire
